### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ steps:
   - label: 'Run a Windows Docker container'
     command: 'docker run microsoft/dotnet-samples:dotnetapp-nanoserver'
     plugins:
-      zsims/win-docker#v0.0.5:
-        aws_instance_type: 't2.medium'
+      - zsims/win-docker#v0.0.5:
+          aws_instance_type: 't2.medium'
 ```
 
 ## Example with Buildkite Docker Plugin (TBD)
@@ -70,15 +70,15 @@ Some of the defaults must be overriden (`mount-buildkite-agent`, and `workdir`) 
 steps:
   - command: 'echo %GREETING% from Windows'
     plugins:
-      zsims/win-docker#v0.0.5:
-        aws_instance_type: 't2.medium'
-      docker#v1.4.0:
-        image: 'microsoft/nanoserver:latest'
-        workdir: 'C:/workdir'
-        mount-buildkite-agent: false
-        shell: 'cmd /c'
-        environment:
-          - GREETING=Hello
+      - zsims/win-docker#v0.0.5:
+          aws_instance_type: 't2.medium'
+      - docker#v1.4.0:
+          image: 'microsoft/nanoserver:latest'
+          workdir: 'C:/workdir'
+          mount-buildkite-agent: false
+          shell: 'cmd /c'
+          environment:
+            - GREETING=Hello
 ```
 
 # Tests


### PR DESCRIPTION
Hi again @zsims 😊

(This is the same as https://github.com/seek-oss/github-merged-pr-buildkite-plugin/pull/20, but I'm not sure which one you'll get to first, so here's all the info again!)

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.